### PR TITLE
Improve dev instructions

### DIFF
--- a/create-react-native-app/README.md
+++ b/create-react-native-app/README.md
@@ -2,4 +2,4 @@
 
 ## Development
 
-`yarn && npm start` will start a watcher that will build artifacts and place them in the build directory.
+`yarn && yarn start` will start a watcher that will build artifacts and place them in the build directory.

--- a/create-react-native-app/README.md
+++ b/create-react-native-app/README.md
@@ -2,4 +2,4 @@
 
 ## Development
 
-`yarn && gulp` will start a watcher that will build artifacts and place them in the build directory.
+`yarn && npm start` will start a watcher that will build artifacts and place them in the build directory.

--- a/create-react-native-app/package.json
+++ b/create-react-native-app/package.json
@@ -12,6 +12,9 @@
   "bin": {
     "create-react-native-app": "./build/index.js"
   },
+  "scripts": {
+    "start": "gulp"
+  },
   "dependencies": {
     "babel-runtime": "^6.9.2",
     "chalk": "^1.1.1",

--- a/react-native-scripts/README.md
+++ b/react-native-scripts/README.md
@@ -2,6 +2,6 @@
 
 ## Development
 
-`yarn && npm start` will start a watcher that will build artifacts and place them in the build directory.
+`yarn && yarn start` will start a watcher that will build artifacts and place them in the build directory.
 
 *Warning*: if you change the template project's dependencies, make sure to update `checkAppName` in `create-react-native-app/src/index.js`.

--- a/react-native-scripts/README.md
+++ b/react-native-scripts/README.md
@@ -2,6 +2,6 @@
 
 ## Development
 
-`yarn && gulp` will start a watcher that will build artifacts and place them in the build directory.
+`yarn && npm start` will start a watcher that will build artifacts and place them in the build directory.
 
 *Warning*: if you change the template project's dependencies, make sure to update `checkAppName` in `create-react-native-app/src/index.js`.

--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -13,6 +13,9 @@
   "bin": {
     "react-native-scripts": "./build/bin/react-native-scripts.js"
   },
+  "scripts": {
+    "start": "gulp"
+  },
   "dependencies": {
     "address": "^1.0.1",
     "babel-runtime": "^6.9.2",


### PR DESCRIPTION
Currently, description says "yarn && gulp" which doesn't work if you have no global gulp installed. This PR adds a new npm script `npm start` which runs gulp (no matter local or global) and replace "yarn && gulp" by "yarn && npm start" in the README.md.