### PR TITLE
Add .flowconfig and instructions to enable Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,24 +81,6 @@ This will start the process of "ejecting" from Create React Native App's build s
 
 **Warning:** Running eject is a **permanent** action. Please use a version control system, such as git, so you can revert back if necessary. An ejected app will require you to have an [Xcode and/or Android Studio environment](https://facebook.github.io/react-native/docs/getting-started.html) set up.
 
-### Adding Flow
-
-Flow is a static type checker that helps you write code with fewer bugs. Check out this [introduction to using static types in JavaScript](https://medium.com/@preethikasireddy/why-use-static-types-in-javascript-part-1-8382da1e0adb) if you are new to this concept.
-
-React Native works with [Flow](http://flowtype.org/) out of the box, as long as your Flow version matches the one used in the version of React Native.
-
-To add a local dependency to the correct Flow version to a Create React Native App project, follow these steps:
-
-1. Find the Flow `[version]` at the bottom of the included [.flowconfig](react-native-scripts/template/.flowconfig)
-2. Run `npm install --save-dev flow-bin@x.y.z` (or `yarn add --dev flow-bin@x.y.z`), where `x.y.z` is the .flowconfig version number.
-3. Add `"flow": "flow"` to the `scripts` section of your `package.json`.
-4. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).
-
-Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors.
-You can optionally use an IDE like [Nuclide](https://nuclide.io/docs/languages/flow/) for a better integrated experience.
-
-To learn more about Flow, check out [its documentation](https://flowtype.org/).
-
 ## Philosophy
 
 * **Minimal "Time to Hello World"**: Create React Native App should reduce the setup time it takes to try building a mobile app to the absolute minimum, ideally on par with React web development (especially as seen with [Create React App](https://github.com/facebookincubator/create-react-app)).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ This will start the process of "ejecting" from Create React Native App's build s
 
 **Warning:** Running eject is a **permanent** action. Please use a version control system, such as git, so you can revert back if necessary. An ejected app will require you to have an [Xcode and/or Android Studio environment](https://facebook.github.io/react-native/docs/getting-started.html) set up.
 
+### Adding Flow
+
+Flow is a static type checker that helps you write code with fewer bugs. Check out this [introduction to using static types in JavaScript](https://medium.com/@preethikasireddy/why-use-static-types-in-javascript-part-1-8382da1e0adb) if you are new to this concept.
+
+React Native works with [Flow](http://flowtype.org/) out of the box, as long as your Flow version matches the one used in the version of React Native.
+
+To add a local dependency to the correct Flow version to a Create React Native App project, follow these steps:
+
+1. Find the Flow `[version]` at the bottom of the included [.flowconfig](react-native-scripts/template/.flowconfig)
+2. Run `npm install --save-dev flow-bin@x.y.z` (or `yarn add --dev flow-bin@x.y.z`), where `x.y.z` is the .flowconfig version number.
+3. Add `"flow": "flow"` to the `scripts` section of your `package.json`.
+4. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).
+
+Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors.
+You can optionally use an IDE like [Nuclide](https://nuclide.io/docs/languages/flow/) for a better integrated experience.
+
+To learn more about Flow, check out [its documentation](https://flowtype.org/).
+
 ## Philosophy
 
 * **Minimal "Time to Hello World"**: Create React Native App should reduce the setup time it takes to try building a mobile app to the absolute minimum, ideally on par with React web development (especially as seen with [Create React App](https://github.com/facebookincubator/create-react-app)).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,5 +12,5 @@ Easiest way to do this, is:
 1. Use [this handy chart](VERSIONS.md) to find out the underlying `react-native` versions of the old and new `expo-sdk`.
 2. Get `react-native` .flowconfig changeset in the React Native repo with `git diff tags/v0.41.0 tags/v0.42.0 -- local-cli/templates/HelloWorld/_flowconfig`
 3. If there are changes, land diff to CRNA [.flowconfig](react-native-scripts/template/.flowconfig) template
-4. To test, follow instructions in [README/Adding Flow](README.md#adding-flow) on a freshly generated project, and do `npm run flow` to ensure the process exits without error.
+4. To test, follow instructions in [README/Adding Flow](react-native-scripts/README.md#adding-flow) on a freshly generated project, and do `npm run flow` to ensure the process exits without error.
 5. If there are new issues with third-party dependencies, fix them upstream or add necessary `[ignore]` fields to .flowconfig.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,12 +2,14 @@
 
 This document contains checklists to be done before releasing new versions.
 
+**TODO**: This is not an exhaustive list. At the moment it contains easy-to-forget steps, so that they would not be forgotten.
+
 ## Verify .flowconfig is up to date after updating expo-sdk
 
 After upgrading the [expo-sdk](https://github.com/exponent/exponent-sdk) version (which transitively updates the `react-native` version), ensure that the [.flowconfig](react-native-scripts/template/.flowconfig) template is up to date.
 
 Easiest way to do this, is:
-1. Use [this handy chart](https://docs.expo.io/versions/latest/sdk/index.html#sdk-version) to find out the underlying `react-native` versions of the old and new `expo-sdk`.
+1. Use [this handy chart](VERSIONS.md) to find out the underlying `react-native` versions of the old and new `expo-sdk`.
 2. Get `react-native` .flowconfig changeset in the React Native repo with `git diff tags/v0.41.0 tags/v0.42.0 -- local-cli/templates/HelloWorld/_flowconfig`
 3. If there are changes, land diff to CRNA [.flowconfig](react-native-scripts/template/.flowconfig) template
 4. To test, follow instructions in [README/Adding Flow](README.md#adding-flow) on a freshly generated project, and do `npm run flow` to ensure the process exits without error.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,14 @@
+# Releasing Create React Native App
+
+This document contains checklists to be done before releasing new versions.
+
+## Verify .flowconfig is up to date after updating expo-sdk
+
+After upgrading the [expo-sdk](https://github.com/exponent/exponent-sdk) version (which transitively updates the `react-native` version), ensure that the [.flowconfig](react-native-scripts/template/.flowconfig) template is up to date.
+
+Easiest way to do this, is:
+1. Use [this handy chart](https://docs.expo.io/versions/latest/sdk/index.html#sdk-version) to find out the underlying `react-native` versions of the old and new `expo-sdk`.
+2. Get `react-native` .flowconfig changeset in the React Native repo with `git diff tags/v0.41.0 tags/v0.42.0 -- local-cli/templates/HelloWorld/_flowconfig`
+3. If there are changes, land diff to CRNA [.flowconfig](react-native-scripts/template/.flowconfig) template
+4. To test, follow instructions in [README/Adding Flow](README.md#adding-flow) on a freshly generated project, and do `npm run flow` to ensure the process exits without error.
+5. If there are new issues with third-party dependencies, fix them upstream or add necessary `[ignore]` fields to .flowconfig.

--- a/react-native-scripts/template/.flowconfig
+++ b/react-native-scripts/template/.flowconfig
@@ -1,0 +1,44 @@
+[ignore]
+; We fork some components by platform
+.*/*[.]android.js
+
+; Ignore "BUCK" generated dirs
+<PROJECT_ROOT>/\.buckd/
+
+; Ignore unexpected extra "@providesModule"
+.*/node_modules/.*/node_modules/fbjs/.*
+
+; Ignore duplicate module providers
+; For RN Apps installed via npm, "Libraries" folder is inside
+; "node_modules/react-native" but in the source repo it is in the root
+.*/Libraries/react-native/React.js
+.*/Libraries/react-native/ReactNative.js
+
+[include]
+
+[libs]
+node_modules/react-native/Libraries/react-native/react-native-interface.js
+node_modules/react-native/flow
+flow/
+
+[options]
+module.system=haste
+
+experimental.strict_type_args=true
+
+munge_underscores=true
+
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
+
+suppress_type=$FlowIssue
+suppress_type=$FlowFixMe
+suppress_type=$FixMe
+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-7]\\|[1-2][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-7]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
+
+unsafe.enable_getters_and_setters=true
+
+[version]
+^0.37.0

--- a/react-native-scripts/template/.flowconfig
+++ b/react-native-scripts/template/.flowconfig
@@ -14,6 +14,19 @@
 .*/Libraries/react-native/React.js
 .*/Libraries/react-native/ReactNative.js
 
+; Additional create-react-native-app ignores
+
+; Ignore duplicate module providers
+.*/node_modules/fbemitter/lib/*
+
+; Ignore misbehaving dev-dependencies
+.*/node_modules/xdl/build/*
+.*/node_modules/reqwest/tests/*
+
+; Ignore missing expo-sdk dependencies (temporarily)
+; https://github.com/exponent/exponent-sdk/issues/36
+.*/node_modules/expo/src/*
+
 [include]
 
 [libs]

--- a/react-native-scripts/template/README.md
+++ b/react-native-scripts/template/README.md
@@ -12,6 +12,7 @@ Below you'll find information about performing common tasks. The most recent ver
   * [npm run android](#npm-run-android)
   * [npm run eject](#npm-run-eject)
 * [Writing and Running Tests](#writing-and-running-tests)
+* [Adding Flow](#adding-flow)
 * [Customizing App Display Name and Icon](#customizing-app-display-name-and-icon)
 * [Sharing and Deployment](#sharing-and-deployment)
   * [Publishing to Expo's React Native Community](#publishing-to-expos-react-native-community)
@@ -68,6 +69,24 @@ To set an app icon, set the `expo.icon` key in `app.json` to be either a local p
 ## Writing and Running Tests
 
 This project is set up to use [jest](https://facebook.github.io/jest/) for tests. You can configure whatever testing strategy you like, but jest works out of the box. Create test files in directories called `__tests__` to have the files loaded by jest. See the [the template project](https://github.com/react-community/create-react-native-app/tree/master/react-native-scripts/template/__tests__) for an example test. The [jest documentation](https://facebook.github.io/jest/docs/getting-started.html) is also a wonderful resource, as is the [React Native testing tutorial](https://facebook.github.io/jest/docs/tutorial-react-native.html).
+
+## Adding Flow
+
+Flow is a static type checker that helps you write code with fewer bugs. Check out this [introduction to using static types in JavaScript](https://medium.com/@preethikasireddy/why-use-static-types-in-javascript-part-1-8382da1e0adb) if you are new to this concept.
+
+React Native works with [Flow](http://flowtype.org/) out of the box, as long as your Flow version matches the one used in the version of React Native.
+
+To add a local dependency to the correct Flow version to a Create React Native App project, follow these steps:
+
+1. Find the Flow `[version]` at the bottom of the included [.flowconfig](.flowconfig)
+2. Run `npm install --save-dev flow-bin@x.y.z` (or `yarn add --dev flow-bin@x.y.z`), where `x.y.z` is the .flowconfig version number.
+3. Add `"flow": "flow"` to the `scripts` section of your `package.json`.
+4. Add `// @flow` to any files you want to type check (for example, to `App.js`).
+
+Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors.
+You can optionally use a plugin for your IDE for a better integrated experience.
+
+To learn more about Flow, check out [its documentation](https://flowtype.org/).
 
 ## Sharing and Deployment
 


### PR DESCRIPTION
As discussed with @dikaiosune and @brentvatne in https://github.com/react-community/create-react-native-app/issues/79, adds

* [x] .flowconfig inherited from underlying react-native version
* [x] .flowconfig [ignore] list to deal with badly behaving dev-dependencies
* [x] .flowconfig [ignore] to temporarily ignore Expo SDK types until https://github.com/exponent/exponent-sdk/issues/36 is solved
* [x] RELEASES.md

Until the ignore for https://github.com/exponent/exponent-sdk/issues/36 is removed, Flow-users will need to generate stubbed types for Expo SDK modules using `flow-typed install`.

