### PR TITLE
Save QR code as png

### DIFF
--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -31,6 +31,7 @@
     "inquirer": "^3.0.1",
     "match-require": "^2.0.0",
     "path-exists": "^3.0.0",
+    "qr-image":"^3.2.0",
     "qrcode-terminal": "^0.11.0",
     "xdl": "^36.0.0"
   },

--- a/react-native-scripts/src/scripts/start.js
+++ b/react-native-scripts/src/scripts/start.js
@@ -5,6 +5,7 @@ import { Config, ProjectSettings, UrlUtils } from 'xdl';
 import chalk from 'chalk';
 import indent from 'indent-string';
 import qr from 'qrcode-terminal';
+import qrImage from 'qr-image';
 
 import packager from '../util/packager';
 
@@ -38,6 +39,14 @@ For links to install the Expo app, please visit ${chalk.underline(chalk.cyan('ht
 
 Logs from serving your app will appear here. Press Ctrl+C at any time to stop.
 `
+    );
+
+    var qrCodeImage = qrImage.image(address, { type: 'png' });
+
+    qrCodeImage.pipe(require('fs').createWriteStream('qrCodeImage.png'));
+
+    console.log(
+      `If the above QR code doesn't work, an image of the same has been saved to your project's root.`
     );
   });
 }


### PR DESCRIPTION
**Fix:** This saves the QR code as PNG, thereby helping people for whom the QR code logged in the terminal doesn't work. (#49)

**Packages Added**

- [qr-image(3.2.0)](https://www.npmjs.com/package/qr-image)