### PR TITLE
Prevent Expo.Components namespace deprecation warning

### DIFF
--- a/react-native-scripts/src/bin/crna-entry.js
+++ b/react-native-scripts/src/bin/crna-entry.js
@@ -1,4 +1,4 @@
-import Expo, { Components } from 'expo';
+import Expo from 'expo';
 import App from '../../../../App';
 import React from 'react';
 import { View } from 'react-native';
@@ -14,7 +14,7 @@ class AwakeApp extends React.Component {
         },
       },
       React.createElement(App, null),
-      React.createElement(Components.KeepAwake, null)
+      React.createElement(Expo.KeepAwake, null)
     );
   }
 }


### PR DESCRIPTION
I started a fresh project and got this warning:

```
Components under `Expo.Components` have been moved to the root `Expo` namespace. For example, `Expo.Components.Video` is now `Expo.Video`. The `Expo.Components` namespace is now deprecated and will be removed in version 17.0.0 of 'expo'.
```

I've made some changes that I think will fix the error but I wasn't able to link to my local version of react-native-scripts to test it.