### PR TITLE
Documentation. Extra details on port accessibility when troubleshooting

### DIFF
--- a/react-native-scripts/template/README.md
+++ b/react-native-scripts/template/README.md
@@ -175,7 +175,9 @@ If you have made use of Expo APIs while working on your project, then those API 
 
 ### Networking
 
-If you're unable to load your app on your phone due to a network timeout or a refused connection, a good first step is to verify that your phone and computer are on the same network and that they can reach each other. Try opening a web browser on your phone and opening the URL that the packager script prints, replacing `exp://` with `http://`. So, for example, if underneath the QR code in your terminal you see:
+If you're unable to load your app on your phone due to a network timeout or a refused connection, a good first step is to verify that your phone and computer are on the same network and that they can reach each other. Create React Native App needs access to ports 19000 and 19001 so ensure that your network and firewall settings allow access from your device to your computer on both of these ports.
+
+Try opening a web browser on your phone and opening the URL that the packager script prints, replacing `exp://` with `http://`. So, for example, if underneath the QR code in your terminal you see:
 
 ```
 exp://192.168.0.1:19000
@@ -185,6 +187,12 @@ Try opening Safari or Chrome on your phone and loading
 
 ```
 http://192.168.0.1:19000
+```
+
+and
+
+```
+http://192.168.0.1:19001
 ```
 
 If this works, but you're still unable to load your app by scanning the QR code, please open an issue on the [Create React Native App repository](https://github.com/react-community/create-react-native-app) with details about these steps and any other error messages you may have received.


### PR DESCRIPTION
This is feedback from #149 where I couldn't get the app to work due to firewall blocking 19001 which wasn't obviously required from the docs. Hopefully this makes it clearer.