### PR TITLE
Add 'v' for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Once you're up and running with Create React Native App, visit [this tutorial](h
 
 ## Quick Overview
 
-Make sure you have Node 6 or later installed. No Xcode or Android Studio installation is required.
+Make sure you have Node v6 or later installed. No Xcode or Android Studio installation is required.
 
 ```sh
 $ npm install -g create-react-native-app


### PR DESCRIPTION
Added 'v' in front of '6' on [line 12](https://github.com/react-community/create-react-native-app/blame/master/README.md#L12) to keep the document more consistent.
[Line 45](https://github.com/react-community/create-react-native-app/blame/master/README.md#L45) specifies versions using 'v' before version numbers and line 12 doesn't.