### PR TITLE
Fix the react-native-scripts watcher

### DIFF
--- a/react-native-scripts/flyfile.js
+++ b/react-native-scripts/flyfile.js
@@ -11,9 +11,13 @@ export default async function (fly) {
 }
 
 export async function babel(fly, opts) {
-  await fly.clear(paths.build).source(opts.src || paths.source).babel().target(paths.build);
+  await fly.source(opts.src || paths.source).babel().target(paths.build);
 }
 
 export async function clean(fly) {
   await fly.clear(paths.build);
+}
+
+export async function build(fly, opts) {
+  await fly.serial(['clean', 'babel'], opts);
 }

--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "start": "fly",
-    "build": "fly babel"
+    "build": "fly build"
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",


### PR DESCRIPTION
Stop the watcher from purging other files from the build folder every time a file a changed.

**Existing behavior**

When the watcher (`yarn start` in react-native-scripts folder) is running, whenever a single file is changed the build script removes all the contents of the `react-native-scripts/build` folder and builds the changed file, resulting in a build folder with just one file.

**Fixed behavior**

The build folder is only purged when running `yarn build`. The watcher only builds changed files.