### PR TITLE
Check for npm v5 only, not v50 or v55

### DIFF
--- a/react-native-scripts/src/scripts/init.js
+++ b/react-native-scripts/src/scripts/init.js
@@ -29,7 +29,7 @@ module.exports = async (appPath: string, appName: string, verbose: boolean, cwd:
   if (!useYarn) {
     let npmVersion = spawn.sync('npm', ['--version']).stdout.toString().trim();
 
-    if (npmVersion.startsWith('5')) {
+    if (npmVersion.match(/\d+/)[0] === '5') {
       console.log(
         chalk.yellow(
           `


### PR DESCRIPTION
This uses a regex to avoid including version numbers that just start with '5' but are actually greater, like '53' or '530'. This was the reason Microsoft couldn’t release Windows 9, because there was lots of code that checked for Windows 95 or Windows 98. npm will be able to avoid that fate ;)