### PR TITLE
Switch Babel preset on eject

### DIFF
--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -35,6 +35,7 @@
     "path-exists": "^3.0.0",
     "progress": "^2.0.0",
     "qrcode-terminal": "^0.11.0",
+    "rimraf": "^2.6.1",
     "xdl": "43.0.0",
     "@expo/bunyan": "1.8.10"
   },

--- a/react-native-scripts/yarn.lock
+++ b/react-native-scripts/yarn.lock
@@ -3153,9 +3153,9 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xdl@42.4.0:
-  version "42.4.0"
-  resolved "https://registry.yarnpkg.com/xdl/-/xdl-42.4.0.tgz#eeae75398090d642c55fce8e955edbf44ea416a0"
+xdl@43.0.0:
+  version "43.0.0"
+  resolved "https://registry.yarnpkg.com/xdl/-/xdl-43.0.0.tgz#d73392fcc654ee22a0d466b6acb782453bfb6a2a"
   dependencies:
     "@ccheever/crayon" "^5.0.0"
     "@expo/bunyan" "^1.8.10"


### PR DESCRIPTION
* Switch from `babel-preset-expo` to `babel-preset-react-native-stage-0` when ejecting.
* Automatically install the `babel-preset-react-native-stage-0` package.
* Also prune removed packages when ejecting. (I got the idea from this from @dikaiosune's comment here: https://github.com/facebook/react-native/pull/15139#issuecomment-317024841). This way the `node_modules` folder will be in a consistent state after eject. This is done by simply removing the `node_modules` folder. (I tried just running `yarn`, which should ensure consistent state and also `npm uninstall <package>` when using npm, but both had issues.)

## Test plan
* Create an app. Eject the app.
* Create an app. Remove `yarn.lock` (forces npm to be used). Eject the app.
  * In both cases, after eject, the app starts, `.babelrc` has the `babel-preset-react-native-stage-0/decorator-support` preset and the preset is installed. `expo` is not found in `node_modules`.
* Create an app. Replace the preset in `.babelrc` with `react-native`. Eject.
  * The preset is not changed and `babel-preset-react-native-stage-0` not installed.