### PR TITLE
Fix Yarn usage instructions

### DIFF
--- a/react-native-scripts/src/scripts/init.js
+++ b/react-native-scripts/src/scripts/init.js
@@ -113,7 +113,7 @@ https://github.com/npm/npm/issues/16991
   let args = [];
 
   if (useYarn) {
-    command = 'yarn';
+    command = 'yarnpkg';
   } else {
     command = 'npm';
     args = ['install', '--save'];
@@ -123,13 +123,9 @@ https://github.com/npm/npm/issues/16991
     }
   }
 
-  log(`Installing dependencies using ${command}...`);
+  const npmOrYarn = useYarn ? 'yarn' : 'npm';
+  log(`Installing dependencies using ${npmOrYarn}...`);
   log(); // why is this here
-
-  if (command === 'yarn') {
-    // Use the more unique `yarnpkg` alias to avoid naming conflicts with other tools.
-    command = 'yarnpkg';
-  }
 
   const proc = spawn(command, args, { stdio: 'inherit' });
   proc.on('close', code => {
@@ -153,30 +149,30 @@ https://github.com/npm/npm/issues/16991
 Success! Created ${appName} at ${appPath}
 Inside that directory, you can run several commands:
 
-  ${chalk.cyan(command + ' start')}
+  ${chalk.cyan(npmOrYarn + ' start')}
     Starts the development server so you can open your app in the Expo
     app on your phone.
 
-  ${chalk.cyan(command + ' run ios')}
+  ${chalk.cyan(npmOrYarn + ' run ios')}
     (Mac only, requires Xcode)
     Starts the development server and loads your app in an iOS simulator.
 
-  ${chalk.cyan(command + ' run android')}
+  ${chalk.cyan(npmOrYarn + ' run android')}
     (Requires Android build tools)
     Starts the development server and loads your app on a connected Android
     device or emulator.
 
-  ${chalk.cyan(command + ' test')}
+  ${chalk.cyan(npmOrYarn + ' test')}
     Starts the test runner.
 
-  ${chalk.cyan(command + ' run eject')}
+  ${chalk.cyan(npmOrYarn + ' run eject')}
     Removes this tool and copies build dependencies, configuration files
     and scripts into the app directory. If you do this, you can’t go back!
 
 We suggest that you begin by typing:
 
   ${chalk.cyan('cd ' + cdpath)}
-  ${chalk.cyan(command + ' start')}`
+  ${chalk.cyan(npmOrYarn + ' start')}`
     );
 
     if (readmeExists) {


### PR DESCRIPTION
I fixed the `yarnpkg` alias usage in #329, but as a regression, the command is now written as `yarnpkg` in the usage instructions 😳
```
Success! Created my-crna-app at /Users/ville/Projects/my-crna-app
Inside that directory, you can run several commands:

  yarnpkg start
    Starts the development server so you can open your app in the Expo
    app on your phone.

  yarnpkg run ios
...
```
This PR changes the instructions back to `yarn` while keeping `yarnpkg` as the command that's actually invoked.

**Test plan**

Ran `npm run build && npm pack` in the `react-scripts` folder and created an app using CRNA:
```
create-react-native-app my-crna-app5 --scripts-version file:/path-to-react-native-scripts.tgz
````
Running `ps` in another terminal during installation displayed `yarnpkg` as the running process and instructions were displayed correctly in the end:
<img width="616" alt="screen shot 2017-08-02 at 21 00 39" src="https://user-images.githubusercontent.com/497214/28887893-744b6f94-77c7-11e7-9e92-912f4c6e6144.png">
