### PR TITLE
Allow scripts to automatically eject

### DIFF
--- a/react-native-scripts/src/index.js
+++ b/react-native-scripts/src/index.js
@@ -1,0 +1,5 @@
+const eject = require("./scripts/eject");
+
+module.exports = {
+  eject: eject.eject
+};

--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -101,25 +101,30 @@ Ejecting is permanent! Please be careful with your selection.
         newDisplayName = expName;
       }
 
+      const validateEnteredDisplayname = s => { return s.length > 0; }
+      const validateEnteredName = s => { return s.length > 0 && s.indexOf('-') === -1 && s.indexOf(' ') === -1; }
+
       log("We have a couple of questions to ask you about how you'd like to name your app:");
       const { enteredName, enteredDisplayname } = parameters !== null ? parameters : await inquirer.prompt([
         {
           name: 'enteredDisplayname',
           message: "What should your app appear as on a user's home screen?",
           default: newDisplayName,
-          validate: s => {
-            return s.length > 0;
-          },
+          validate: validateEnteredDisplayname,
         },
         {
           name: 'enteredName',
           message: 'What should your Android Studio and Xcode projects be called?',
           default: newName,
-          validate: s => {
-            return s.length > 0 && s.indexOf('-') === -1 && s.indexOf(' ') === -1;
-          },
+          validate: validateEnteredName,
         },
       ]);
+      if (!validateEnteredName(enteredName)) {
+        throw new Error("Invalid enteredName");
+      }
+      if (!validateEnteredDisplayname(enteredDisplayname)) {
+        throw new Error("Invalid enteredDisplayname");
+      }
 
       appJson.name = enteredName;
       appJson.displayName = enteredDisplayname;

--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -11,7 +11,10 @@ import log from '../util/log';
 
 import { detach } from '../util/expo';
 
-async function eject() {
+async function eject(parameters) {
+  if (typeof parameters === 'undefined') {
+    parameters = null;
+  }
   try {
     const filesWithExpo = await filesUsingExpoSdk();
     const usingExpo = filesWithExpo.length > 0;
@@ -75,7 +78,7 @@ Ejecting is permanent! Please be careful with your selection.
       },
     ];
 
-    const { ejectMethod } = await inquirer.prompt(questions);
+    const { ejectMethod } = parameters !== null ? parameters : await inquirer.prompt(questions);
 
     if (ejectMethod === 'raw') {
       const useYarn = await fse.exists(path.resolve('yarn.lock'));
@@ -99,7 +102,7 @@ Ejecting is permanent! Please be careful with your selection.
       }
 
       log("We have a couple of questions to ask you about how you'd like to name your app:");
-      const { enteredName, enteredDisplayname } = await inquirer.prompt([
+      const { enteredName, enteredDisplayname } = parameters !== null ? parameters : await inquirer.prompt([
         {
           name: 'enteredDisplayname',
           message: "What should your app appear as on a user's home screen?",
@@ -328,13 +331,17 @@ async function findJavaScriptProjectFilesInRoot(root: string): Promise<Array<str
   }
 }
 
-eject()
-  .then(() => {
-    // the expo local github auth server leaves a setTimeout for 5 minutes
-    // so we need to explicitly exit (for now, this will be resolved in the nearish future)
-    process.exit(0);
-  })
-  .catch(e => {
-    console.error(`Problem running eject: ${e}`);
-    process.exit(1);
-  });
+if (require.main === module) {
+  eject()
+    .then(() => {
+      // the expo local github auth server leaves a setTimeout for 5 minutes
+      // so we need to explicitly exit (for now, this will be resolved in the nearish future)
+      process.exit(0);
+    })
+    .catch(e => {
+      console.error(`Problem running eject: ${e}`);
+      process.exit(1);
+    });
+} else {
+  module.exports = { eject: eject };
+}


### PR DESCRIPTION
Following the rejection of PR #202 , fixes #196.

[In a comment on #202](https://github.com/react-community/create-react-native-app/pull/202#issuecomment-319206327) it was suggested to refactor `eject.js` to make it possible for other scripts to do the eject for you.

Using the changes in these two commits, I was able to make a script like this from a CRNA-project:

    const rns = require("react-native-scripts/build");
    rns.eject({
      ejectMethod: "raw",
      enteredName: "ProjectName",
      enteredDisplayname: "My project"
    });

I didn't manage to make a `index.js` file go to `react-native-scripts/index.js` as [`taskfile.js` specifies to build `src` directory](https://github.com/react-community/create-react-native-app/blob/master/react-native-scripts/taskfile.js#L5), if anyone else has another solution for that (or anything else that can be improved in this PR) then feel free to improve on that or suggest improvements.