### PR TITLE
Update RN 0.49.3, React 16.0.0-beta5, and Expo 22.0.0

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,3 +20,4 @@ Each version of these dependencies is only compatible with a narrow version rang
 | 0.46.x         | 16.0.0-alpha.12 | 19.x.x | `"19.0.0"`               |
 | 0.47.x         | 16.0.0-alpha.12 | 20.x.x | `"20.0.0"`               |
 | 0.48.x         | 16.0.0-alpha.12 | 21.x.x | `"21.0.0"`               |
+| 0.49.x         | 16.0.0-beta.5   | 22.x.x | `"22.0.0"`               |

--- a/react-native-scripts/package.json
+++ b/react-native-scripts/package.json
@@ -38,7 +38,7 @@
     "progress": "^2.0.0",
     "qrcode-terminal": "^0.11.0",
     "rimraf": "^2.6.1",
-    "xdl": "45.0.0"
+    "xdl": "46.0.1"
   },
   "devDependencies": {
     "@taskr/babel": "^1.0.6",

--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -205,16 +205,14 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
 
       log(chalk.green('Your package.json is up to date!'));
 
-      // FIXME now we need to provide platform-specific entry points until upstream uses a single one
-      log(`Adding platform-specific entry points...`);
+      log(`Adding entry point...`);
 
       const lolThatsSomeComplexCode = `import { AppRegistry } from 'react-native';
 import App from './App';
 AppRegistry.registerComponent('${newName}', () => App);
 `;
 
-      await fse.writeFile(path.resolve('index.ios.js'), lolThatsSomeComplexCode);
-      await fse.writeFile(path.resolve('index.android.js'), lolThatsSomeComplexCode);
+      await fse.writeFile(path.resolve('index.js'), lolThatsSomeComplexCode);
 
       log(chalk.green('Added new entry points!'));
 

--- a/react-native-scripts/src/scripts/init.js
+++ b/react-native-scripts/src/scripts/init.js
@@ -10,15 +10,15 @@ import install from '../util/install';
 
 // UPDATE DEPENDENCY VERSIONS HERE
 const DEFAULT_DEPENDENCIES = {
-  expo: '^21.0.0',
-  react: '16.0.0-alpha.12',
-  'react-native': '^0.48.4',
+  expo: '^22.0.0',
+  react: '16.0.0-beta.5',
+  'react-native': '^0.49.3',
 };
 
 // TODO figure out how this interacts with ejection
 const DEFAULT_DEV_DEPENDENCIES = {
-  'jest-expo': '^21.0.2',
-  'react-test-renderer': '16.0.0-alpha.12',
+  'jest-expo': '^22.0.0',
+  'react-test-renderer': '16.0.0-beta.5',
 };
 
 module.exports = async (appPath: string, appName: string, verbose: boolean, cwd: string = '') => {

--- a/react-native-scripts/template/app.json
+++ b/react-native-scripts/template/app.json
@@ -1,5 +1,5 @@
 {
   "expo": {
-    "sdkVersion": "21.0.0"
+    "sdkVersion": "22.0.0"
   }
 }

--- a/react-native-scripts/yarn.lock
+++ b/react-native-scripts/yarn.lock
@@ -26,9 +26,9 @@
     babel-runtime "^6.23.0"
     exec-async "^2.2.0"
 
-"@expo/schemer@1.0.44":
-  version "1.0.44"
-  resolved "https://registry.yarnpkg.com/@expo/schemer/-/schemer-1.0.44.tgz#d74a94ba0217f160c1a86ce1c6a42f581485a542"
+"@expo/schemer@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/schemer/-/schemer-1.1.0.tgz#74e519233f82c8871d018475895043e4caef3e7e"
   dependencies:
     ajv "^5.2.2"
     babel-polyfill "^6.23.0"
@@ -873,6 +873,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base64-js@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
+
 base64url@2.0.0, base64url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
@@ -1552,6 +1556,10 @@ gauge@~2.7.3:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+getenv@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/getenv/-/getenv-0.7.0.tgz#39b91838707e2086fd1cf6ef8777d1c93e14649e"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -2516,6 +2524,14 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+plist@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-2.1.0.tgz#57ccdb7a0821df21831217a3cad54e3e146a1025"
+  dependencies:
+    base64-js "1.2.0"
+    xmlbuilder "8.2.2"
+    xmldom "0.1.x"
+
 prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -3338,14 +3354,14 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xdl@45.0.0:
-  version "45.0.0"
-  resolved "https://registry.yarnpkg.com/xdl/-/xdl-45.0.0.tgz#427b7f5e22151ed3124aba7b8e01989601fa43ee"
+xdl@^46.0.1:
+  version "46.0.1"
+  resolved "https://registry.yarnpkg.com/xdl/-/xdl-46.0.1.tgz#dd3ae023ccd00e9e81ec79327692db443cb88a18"
   dependencies:
     "@expo/bunyan" "^1.8.10"
     "@expo/json-file" "^5.3.0"
     "@expo/osascript" "^1.8.0"
-    "@expo/schemer" "1.0.44"
+    "@expo/schemer" "1.1.0"
     "@expo/spawn-async" "^1.2.8"
     analytics-node "^2.1.0"
     auth0 "^2.7.0"
@@ -3360,6 +3376,7 @@ xdl@45.0.0:
     file-type "^4.0.0"
     freeport-async "^1.1.1"
     fs-extra "^0.30.0"
+    getenv "^0.7.0"
     glob "^7.0.3"
     hasbin "^1.2.3"
     home-dir "^1.0.0"
@@ -3377,6 +3394,7 @@ xdl@45.0.0:
     mz "^2.6.0"
     ncp "^2.0.0"
     opn "^4.0.2"
+    plist "2.1.0"
     querystring "^0.2.0"
     raven "^2.1.1"
     raven-js "^3.17.0"
@@ -3397,7 +3415,11 @@ xdl@45.0.0:
     xmldom "^0.1.27"
     yesno "^0.0.1"
 
-xmldom@^0.1.27:
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+
+xmldom@0.1.x, xmldom@^0.1.27:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 


### PR DESCRIPTION
Changes
- React Native 0.49.3, React 16.0.0-beta.5, and Expo 22.0.0 (also jest-expo)
- While ejecting, create `index.js` as a single entry point instead of platform specific since react-native 0.49 now use single entry point when init project - https://github.com/facebook/react-native/releases/tag/v0.49.0)


I have tested by create react-native project via CRNA on my local machine and it works. Also tested eject into raw react-native project as well.