### PR TITLE
Remove jest-expo plugin on eject and use jest-react-native instead

### DIFF
--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -200,6 +200,8 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
       if (pkgJson.jest.preset === 'jest-expo') {
         pkgJson.jest.preset = 'react-native';
         newDevDependencies.push('jest-react-native');
+      } else {
+        log(`${chalk.bold('Warning')}: it looks like you've changed the Jest preset from jest-expo to ${pkgJson.jest.preset}. We recommend you make sure this Jest preset is compatible with ejected apps.`)
       }
 
       // no longer relevant to an ejected project (maybe build is?)

--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -197,8 +197,10 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
       pkgJson.scripts.ios = 'react-native run-ios';
       pkgJson.scripts.android = 'react-native run-android';
 
-      pkgJson.jest.preset = 'react-native';
-      newDevDependencies.push('jest-react-native');
+      if (pkgJson.jest.preset === 'jest-expo') {
+        pkgJson.jest.preset = 'react-native';
+        newDevDependencies.push('jest-react-native');
+      }
 
       // no longer relevant to an ejected project (maybe build is?)
       delete pkgJson.scripts.eject;

--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -191,10 +191,14 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
       // missing native modules will cause
       delete pkgJson.dependencies.expo;
       delete pkgJson.devDependencies['react-native-scripts'];
+      delete pkgJson.devDependencies['jest-expo'];
 
       pkgJson.scripts.start = 'react-native start';
       pkgJson.scripts.ios = 'react-native run-ios';
       pkgJson.scripts.android = 'react-native run-android';
+
+      pkgJson.jest.preset = 'react-native';
+      newDevDependencies.push('jest-react-native');
 
       // no longer relevant to an ejected project (maybe build is?)
       delete pkgJson.scripts.eject;


### PR DESCRIPTION
Resolve #47

When I run `npm run eject` and try to run jest tests by `npm test`, it fails with `Cannot find module 'expo' from 'setup.js'`. So we have to remove expo jest preset and use react-native instead. 

I'm not sure if it is ok to replace it with `jest-react-native` for everyone but in my case removing `jest-expo` and using `jest-react-native` fixed the issue