### PR TITLE
Update test script in react-native-scripts

### DIFF
--- a/react-native-scripts/src/scripts/init.js
+++ b/react-native-scripts/src/scripts/init.js
@@ -70,7 +70,7 @@ https://github.com/npm/npm/issues/16991
     eject: 'react-native-scripts eject',
     android: 'react-native-scripts android',
     ios: 'react-native-scripts ios',
-    test: 'node node_modules/jest/bin/jest.js --watch',
+    test: 'node node_modules/jest/bin/jest.js -o',
   };
 
   appPackage.jest = {


### PR DESCRIPTION
Hi,

I installed `create-react-native-app` and ran `yarn test` before any changes. Unfortunately, I’ve got an error:

```
Determining test suites to run...Error: This promise must be present when running with -o.
    at /Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/search_source.js:202:17
    at Generator.next (<anonymous>)
    at step (/Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/search_source.js:19:362)
    at /Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/search_source.js:19:592
    at new Promise (<anonymous>)
    at /Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/search_source.js:19:273
    at SearchSource.getTestPaths (/Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/search_source.js:216:10)
    at /Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/run_jest.js:44:29
    at Generator.next (<anonymous>)
    at step (/Users/arthurkhusaenov/Codes/AwesomeProject/node_modules/jest-cli/build/run_jest.js:23:380)
 
```
This error gives me no idea why it happens and how to fix it. 

So I took a look at [Jest docs](https://facebook.github.io/jest/docs/en/cli.html#running-from-the-command-line) and found that `jest --watch` runs `jest -o` by default. Then I tried `node node_modules/jest/bin/jest.js 
-o` and it gave the clear message:

```
Jest can only find uncommitted changed files in a git or hg repository. If you make your project a git or hg repository (`git init` or `hg init`), Jest will be able to only run tests related to files changed since the last commit.
No tests found related to files changed since last commit. 
```

Now I understand that I should initialize git before. So I suggest to change `--watch` to `-o`.

**Edited:** it was a mistake to open PR, I had to open an issue before or better to open it in jest repo.