### PR TITLE
Updated flowconfig in template

### DIFF
--- a/react-native-scripts/template/.flowconfig
+++ b/react-native-scripts/template/.flowconfig
@@ -69,7 +69,5 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(5[0-6]\\|[1-4][0-9]\\|
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
-unsafe.enable_getters_and_setters=true
-
 [version]
 ^0.56.0

--- a/react-native-scripts/template/.flowconfig
+++ b/react-native-scripts/template/.flowconfig
@@ -70,4 +70,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.56.0
+^0.62.1


### PR DESCRIPTION
Guys, I made a very small changes, but I encountered a problems when was trying to use the template for flow.

First, I updated a flow version to 0.62
Second, "The unsafe.enable_getters_and_setters option was removed in 0.62.0; getters and setters are now enabled by default." 