### PR TITLE
documentation - add watchman instructions in the installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Make sure you have Node v6 or later installed. No Xcode or Android Studio instal
 $ npm install -g create-react-native-app
 $ create-react-native-app my-app
 $ cd my-app/
-$ npm start
+$ yarn start
 ```
 
 Install the [Expo](https://expo.io) app on your iOS or Android phone, and use the QR code in the terminal to open your app. Find the QR scanner on the Projects tab of the app. When you're ready to share your project with others (for example, by deploying to an app store), read the [Sharing & Deployment](https://github.com/react-community/create-react-native-app/blob/master/react-native-scripts/template/README.md#sharing-and-deployment) section of the User Guide.
@@ -45,6 +45,17 @@ $ yarn global add create-react-native-app
 
 You'll need to have Node v6 or later on your machine. We strongly recommend using npm v3, v4, or a recent version of Yarn. Create React Native App does not currently work with npm v5 due to bugs in npm ([you can track the issue here](https://github.com/react-community/create-react-native-app/issues/233#issuecomment-305638103)).
 
+#### Watchman
+
+You'll need [Watchman](https://facebook.github.io/watchman/docs/install.html) to run your app
+
+As an alternative you can run the following in your terminal:
+
+```
+sudo sysctl -w kern.maxfiles=5242880
+sudo sysctl -w kern.maxfilesperproc=524288
+```
+
 ### Creating an App
 
 To create a new app, run:
@@ -58,25 +69,25 @@ This will create a directory called `my-app` inside the current working director
 
 If you're familiar with React Native already, you won't find any `ios` or `android` directories in this project, just JavaScript. Once this installation is done, there are some commands you can run in the project directory:
 
-#### `npm start`
+#### `yarn start`
 
 Runs your app in development mode with an interactive prompt. To run it without a prompt, use the `--no-interactive` flag.
 
 Open it in the [Expo app](https://expo.io) on your phone to view it. It will reload if you save edits to your files, and you will see build errors and logs in the terminal.
 
-#### `npm test`
+#### `yarn test`
 
 Runs the [jest](https://github.com/facebook/jest) test runner on your tests.
 
-#### `npm run ios`
+#### `yarn run ios`
 
-Like `npm start`, but also attempts to open your app in the iOS Simulator if you're on a Mac and have it installed.
+Like `yarn start`, but also attempts to open your app in the iOS Simulator if you're on a Mac and have it installed.
 
-#### `npm run android`
+#### `yarn run android`
 
-Like `npm start`, but also attempts to open your app on a connected Android device or emulator. Requires an installation of Android build tools (see [React Native docs](https://facebook.github.io/react-native/docs/getting-started.html) for detailed setup).
+Like `yarn start`, but also attempts to open your app on a connected Android device or emulator. Requires an installation of Android build tools (see [React Native docs](https://facebook.github.io/react-native/docs/getting-started.html) for detailed setup).
 
-#### `npm run eject`
+#### `yarn run eject`
 
 This will start the process of "ejecting" from Create React Native App's build scripts. You'll be asked a couple of questions about how you'd like to build your project.
 


### PR DESCRIPTION
Hello!

I am a first-time create-react-native-app user and ran into the error `unable to start server` on `yarn start` as outlined in https://github.com/react-community/create-react-native-app/issues/533

The fix was to install watchman, but I didn't see any reference in the README.
So, I thought I'd add a small blurb on it.

I also replaced the command npm with yarn to match the command line output when creating a new app.

Thank you!
Abe
