### PR TITLE
Corrected link to /graphs/contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For details about setting up a development environment and testing your changes,
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="graphs/contributors"><img src="https://opencollective.com/create-react-native-app/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/react-community/create-react-native-app/graphs/contributors"><img src="https://opencollective.com/create-react-native-app/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers


### PR DESCRIPTION
Using a relative URL appends `/blobs/master` to the URL. Updated to use the full URL to the page.