### PR TITLE
refactor init output to a config that takes care of output

### DIFF
--- a/react-native-scripts/src/scripts/start.js
+++ b/react-native-scripts/src/scripts/start.js
@@ -68,7 +68,8 @@ async function printServerInfo() {
     emulatorHelp = `Press ${chalk.bold('a')} to start an Android emulator.`;
   }
   qr.generate(address, qrCode => {
-    log(`
+    log(
+      `
 ${indent(qrCode, 2)}
 
 Your app is now running at URL: ${chalk.underline(chalk.cyan(address))}


### PR DESCRIPTION
Hi! I did some refinements to the way you output after scaffolding. By creating a config prop you have more control if you decide to add more commands or to remove some. Tested and it works as the old setup. 

Personally think this is more developer-friendly for maintenance reasons. 