### PR TITLE
Fix "npm start" stuck at Starting Packager... on Windows 10

### DIFF
--- a/react-native-scripts/src/util/packager.js
+++ b/react-native-scripts/src/util/packager.js
@@ -126,7 +126,7 @@ ${chalk.cyan(`  sudo sysctl -w kern.maxfiles=5242880
       return;
     }
 
-    if (chunk.msg === 'Dependency graph loaded.') {
+    if (chunk.msg === 'Dependency graph loaded.' || chunk.msg === 'Metro Bundler ready.') {
       packagerReady = true;
       onReady();
       return;


### PR DESCRIPTION
I had this problem with an app created using create-react-native-app and running with `npm start`. For some reason, it would get stuck in the "Starting packager" message (I'm on Windows 10), but it would actually be working. Only thing missing was to print the QR Code and all the text. To make it clear, if I connected a device with the expo app to this development server, it would work, build the bundle and download to the app. But it wouldn't print the message saying it's ready. 

Digging around the code, I found that the problem is just that it doesn't detect the message from Metro Bundler, it expects a different string. So I'm just checking for the string that my Metro bundler prints and everything is back to normal. 

Just for the record, here is my environment: 


```
ver
Microsoft Windows [Versión 10.0.16299.431]

node -v
v8.11.1

npm --version
6.1.0

npm ls react-native-scripts
`-- react-native-scripts@1.14.1

npm ls react-native
`-- react-native@0.55.2

npm ls expo
`-- expo@27.0.2
```

Hope it helps somebody ot there. 