### PR TITLE
Updating instructions to run the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ cd my-app/
 $ npm start
 ```
 
-The `npm start` command starts the packager. You can now open the App on your phone by using the Expo app.
+The `npm start` command starts the packager. You can now run the project on your phone by using the Expo app.
 
 ### Android
 
@@ -28,8 +28,8 @@ The `npm start` command starts the packager. You can now open the App on your ph
 
 ### iOS
 
-- Install the [Expo](https://expo.io) app on your android phone.
-- Press 's' in the terminal to send the expo link to your email address or phone number. This link can be used to open your project from the Expo app.
+- Install the [Expo](https://expo.io) app on your iOS phone.
+- Press 's' in the terminal to send the expo link to your email address or phone number. This link can be used to run your project from the Expo app.
 
 Create React Native App allows you to work with all of the [Components and APIs](https://facebook.github.io/react-native/docs/getting-started.html) in React Native, as well as most of the [JavaScript APIs](https://docs.expo.io/versions/latest/sdk/index.html) that the Expo App provides.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ $ cd my-app/
 $ npm start
 ```
 
-Install the [Expo](https://expo.io) app on your iOS or Android phone, and use the QR code in the terminal to open your app. Find the QR scanner on the Projects tab of the app. When you're ready to share your project with others (for example, by deploying to an app store), read the [Sharing & Deployment](https://github.com/react-community/create-react-native-app/blob/master/react-native-scripts/template/README.md#sharing-and-deployment) section of the User Guide.
+The `npm start` command starts the packager. You can now open the App on your phone by using the Expo app.
+
+### Android
+
+- Install the [Expo](https://expo.io) app on your android phone.
+- Scan the QR code in your terminal from the Expo app to run the project on your phone.
+
+### iOS
+
+- Install the [Expo](https://expo.io) app on your android phone.
+- Press 's' in the terminal to send the expo link to your email address or phone number. This link can be used to open your project from the Expo app.
 
 Create React Native App allows you to work with all of the [Components and APIs](https://facebook.github.io/react-native/docs/getting-started.html) in React Native, as well as most of the [JavaScript APIs](https://docs.expo.io/versions/latest/sdk/index.html) that the Expo App provides.
 
@@ -151,5 +161,3 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 <a href="https://opencollective.com/create-react-native-app/sponsor/7/website" target="_blank"><img src="https://opencollective.com/create-react-native-app/sponsor/7/avatar.svg"></a>
 <a href="https://opencollective.com/create-react-native-app/sponsor/8/website" target="_blank"><img src="https://opencollective.com/create-react-native-app/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/create-react-native-app/sponsor/9/website" target="_blank"><img src="https://opencollective.com/create-react-native-app/sponsor/9/avatar.svg"></a>
-
-

--- a/react-native-scripts/template/README.md
+++ b/react-native-scripts/template/README.md
@@ -15,7 +15,7 @@ Below you'll find information about performing common tasks. The most recent ver
 * [Environment Variables](#environment-variables)
   * [Configuring Packager IP Address](#configuring-packager-ip-address)
 * [Customizing App Display Name and Icon](#customizing-app-display-name-and-icon)
-* [Sharing and Deployment](#sharing-and-deployment)
+* [Deployment](#sharing-and-deployment)
   * [Publishing to Expo's React Native Community](#publishing-to-expos-react-native-community)
   * [Building an Expo "standalone" app](#building-an-expo-standalone-app)
   * [Ejecting from Create React Native App](#ejecting-from-create-react-native-app)
@@ -123,24 +123,13 @@ npm start
 
 The above example would cause the development server to listen on `exp://my-custom-ip-address-or-hostname:19000`.
 
-## Sharing and Deployment
+## Deployment
 
 Create React Native App does a lot of work to make app setup and development simple and straightforward, but it's very difficult to do the same for deploying to Apple's App Store or Google's Play Store without relying on a hosted service.
 
-### Publishing to Expo's React Native Community
-
-Expo provides free hosting for the JS-only apps created by CRNA, allowing you to share your app through the Expo client app. This requires registration for an Expo account.
-
-Install the `exp` command-line tool, and run the publish command:
-
-```
-$ npm i -g exp
-$ exp publish
-```
-
 ### Building an Expo "standalone" app
 
-You can also use a service like [Expo's standalone builds](https://docs.expo.io/versions/latest/guides/building-standalone-apps.html) if you want to get an IPA/APK for distribution without having to build the native code yourself.
+You can use a service like [Expo's standalone builds](https://docs.expo.io/versions/latest/guides/building-standalone-apps.html) if you want to get an IPA/APK for distribution without having to build the native code yourself.
 
 ### Ejecting from Create React Native App
 


### PR DESCRIPTION
Since there is no QR code scanner in the Expo iOS app anymore, this PR updates the instructions to run the app on the iOS devices.

Also, expo does not allow sharing apps publicly anymore. Removed the `expo publish` part from the `Sharing and Deployment` section.