### PR TITLE
Fix eject script writing default name to index.js file even when custom name is entered

### DIFF
--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -223,7 +223,7 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
 
       const lolThatsSomeComplexCode = `import { AppRegistry } from 'react-native';
 import App from './App';
-AppRegistry.registerComponent('${newName}', () => App);
+AppRegistry.registerComponent('${enteredName}', () => App);
 `;
 
       await fse.writeFile(path.resolve('index.js'), lolThatsSomeComplexCode);


### PR DESCRIPTION
<img width="739" alt="create-react-native-app--eject-bug" src="https://user-images.githubusercontent.com/123357/41501635-949f0950-71a8-11e8-8b38-6dc785f4a265.png">

The bug occurs when a custom name is entered as a response to the question "What should your Android Studio and Xcode projects be called?" during the eject process.

The custom value (in this case 'nativeprojectname') is correctly written to to files MainActivity.java and AppDelegate.m. But the value written to the index.js file is always the suggested default value (here 'onemoreapp') and not the one entered by the user.

This results in the error 'Application nativeprojectname has not been registered' when trying to run the ejected application, whenever a custom name has been entered during the ejection process.

<img width="100" alt="create-react-native-app--eject-bug--error-message" src="https://user-images.githubusercontent.com/123357/41501679-3aae9cca-71a9-11e8-9989-01d0b843f139.jpg">


