### PR TITLE
Add instructions on using iOS Camera app to scan the QR code

### DIFF
--- a/react-native-scripts/src/scripts/start.js
+++ b/react-native-scripts/src/scripts/start.js
@@ -79,6 +79,7 @@ ${chalk.bold('View your app with live reloading:')}
     -> Point the Expo app to the QR code above.
        (You'll find the QR scanner on the Projects tab of the app.)
   ${chalk.underline('iOS device:')}
+    -> Point the iOS Camera app to the QR code above, or
     -> Press ${chalk.bold('s')} to email/text the app URL to your phone.
   ${chalk.underline('Emulator:')}
     -> ${emulatorHelp}


### PR DESCRIPTION
You can use the native Camera app in iOS to scan QR codes. This PR adds this tidbit of info to the start script so users don't need to send the URL via email/text.