### PR TITLE
Added Bundle tasks to raw package.json

### DIFF
--- a/react-native-scripts/src/scripts/eject.js
+++ b/react-native-scripts/src/scripts/eject.js
@@ -198,6 +198,8 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
       pkgJson.scripts.ios = 'react-native run-ios';
       pkgJson.scripts.android = 'react-native run-android';
       pkgJson.scripts.test = 'jest';
+      pkgJson.scripts['bundle-android'] = 'react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/'
+      pkgJson.scripts['bundle-ios'] = 'react-native bundle --entry-file index.js --platform ios --dev false --bundle-output ios/main.jsbundle --assets-dest ios'
 
       newDevDependencies.push('jest');
 


### PR DESCRIPTION
Once the user runs the eject command, these tasks can be used to bundle release files for android and ios. This is something I keep as an command alias. If this is helpful for others please accept.