### PR TITLE
Incorrect setting of __DEV__ in Webpack config

### DIFF
--- a/react-native-scripts/template-with-web/webpack.config.js
+++ b/react-native-scripts/template-with-web/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = {
     // wish to include additional optimizations.
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
-      __DEV__: process.env.NODE_ENV === 'production' || true,
+      __DEV__: 'production' !== process.env.NODE_ENV,
     }),
   ],
 


### PR DESCRIPTION
In current behaviour, if `NODE_ENV` is `production`, then `__DEV__` will be set as `true` - which is not as expected.

Expected behaviour is for `__DEV__` to be `true` always except when `NODE_ENV` is `production`. This PR makes that fix.