### PR TITLE
Add .gitignore info for ejected apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,46 @@
+# Basic Create React Native App
 node_modules
 build/
 yarn-error.log
 *.tgz
 .DS_Store
 *.log
+
+# If you eject your app, uncomment Xcode, Android Studio, Buck and Bundle below.
+
+# Xcode
+#
+# *.pbxuser
+# !default.pbxuser
+# *.mode1v3
+# !default.mode1v3
+# *.mode2v3
+# !default.mode2v3
+# *.perspectivev3
+# !default.perspectivev3
+# xcuserdata
+# *.xccheckout
+# *.moved-aside
+# DerivedData
+# *.hmap
+# *.ipa
+# *.xcuserstate
+# project.xcworkspace
+
+# Android Studio
+#
+# build/
+# .idea
+# .gradle
+# local.properties
+# *.iml
+
+# BUCK
+#
+# buck-out/
+# \.buckd/
+# *.keystore
+
+# Bundle artifact
+#
+# *.jsbundle


### PR DESCRIPTION
Current .gitignore for Create React Native App is not useful after ejecting and causes lots of random files to be added to git.

This .gitignore ignores all the configuration files that Xcode and Android Studio create on ejecting.

Fixes: https://github.com/react-community/create-react-native-app/issues/487